### PR TITLE
Fixed bug when evaluating truthiness for numeric values for prep and cost

### DIFF
--- a/src/server/RecipeManagement.js
+++ b/src/server/RecipeManagement.js
@@ -259,13 +259,13 @@ export function filterRecipes(recipeList, filterCriteria) {
         const numericPrep = prepTime !== undefined ? Number(prepTime) : undefined;
         const numericCost = cost !== undefined ? Number(cost) : undefined;
 
-        if (numericPrep && recipe.prepTime > numericPrep) {
+        if ((numericPrep || numericPrep === 0) && recipe.prepTime > numericPrep) {
             return false
         }
         if (difficulty && getDifficultyLevel(recipe.difficulty) > getDifficultyLevel(difficulty)) {
             return false
         }
-        if (numericCost && recipe.cost > numericCost) {
+        if ((numericCost || numericCost === 0) && recipe.cost > numericCost) {
             return false
         }
         if (dietaryTags && recipe.dietaryTags) {

--- a/src/server/Server.js
+++ b/src/server/Server.js
@@ -66,8 +66,6 @@ app.post("/change-password", (req, res) => {
 });
 
 app.get("/user/:key", (req, res) => {
-    console.log("Hello")
-    console.log(req.session.username)
     if (!req.session.username) {
         return res.send(undefined)
     }


### PR DESCRIPTION
When checking if a filter value was provided for meal prep time and cost, 0 evaluates to false even though it is provided (it should evaluate to true)
Fix : explicitly check if the provided value is 0