### PR TITLE
feat: prevent duplicate meals in weekly meal planner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1458,7 +1457,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1626,7 +1624,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1766,7 +1763,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2153,7 +2149,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3289,7 +3284,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3412,7 +3406,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3422,7 +3415,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3979,7 +3971,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4206,7 +4197,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/__tests__/MealPlanManagement.test.js
+++ b/src/__tests__/MealPlanManagement.test.js
@@ -1,0 +1,147 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+// Mock filesystem so tests don't touch real files
+vi.mock('fs', () => ({
+    default: {
+        existsSync: vi.fn(() => false),
+        readFileSync: vi.fn(() => '[]'),
+        writeFileSync: vi.fn(),
+    },
+}))
+
+// Mock UserManagement (needed by RecipeManagement which MealPlanManagement imports)
+vi.mock('../server/UserManagement.js', () => ({
+    getFriends: vi.fn(() => []),
+}))
+
+import fs from 'fs'
+import { getFriends } from '../server/UserManagement.js'
+import { loadRecipes, addRecipe } from '../server/RecipeManagement.js'
+import {
+    loadMealPlans,
+    assignMeal,
+    getMealPlan,
+    removeMeal,
+} from '../server/MealPlanManagement.js'
+
+const WEEK = '2026-04-06' // a Monday
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    fs.existsSync.mockReturnValue(false)
+    fs.readFileSync.mockReturnValue('[]')
+    fs.writeFileSync.mockImplementation(() => {})
+    loadRecipes()
+    loadMealPlans()
+})
+
+/** Helper: create a recipe owned by `user` and return its id */
+function createRecipe(user, title = 'Test Recipe') {
+    const result = addRecipe(user, {
+        title,
+        ingredients: ['ingredient1'],
+        instructions: 'Do the thing',
+    })
+    return result.recipe.id
+}
+
+describe('assignMeal', () => {
+    it('assigns a meal successfully', () => {
+        const recipeId = createRecipe('alice')
+        const result = assignMeal('alice', WEEK, 'Monday', 'Breakfast', recipeId)
+        expect(result.success).toBe(true)
+        expect(result.plan.meals['Monday']['Breakfast'].recipeId).toBe(recipeId)
+    })
+
+    it('rejects a duplicate recipe in the same week', () => {
+        const recipeId = createRecipe('alice')
+
+        // First assignment succeeds
+        const first = assignMeal('alice', WEEK, 'Monday', 'Breakfast', recipeId)
+        expect(first.success).toBe(true)
+
+        // Second assignment of the SAME recipe to a DIFFERENT slot should fail
+        const second = assignMeal('alice', WEEK, 'Wednesday', 'Dinner', recipeId)
+        expect(second.success).toBe(false)
+        expect(second.message).toContain('already planned')
+    })
+
+    it('allows the same recipe in different weeks', () => {
+        const recipeId = createRecipe('alice')
+
+        const week1 = assignMeal('alice', WEEK, 'Monday', 'Breakfast', recipeId)
+        expect(week1.success).toBe(true)
+
+        const nextWeek = '2026-04-13'
+        const week2 = assignMeal('alice', nextWeek, 'Monday', 'Breakfast', recipeId)
+        expect(week2.success).toBe(true)
+    })
+
+    it('allows re-assigning a recipe to the same slot (overwrite)', () => {
+        const recipeId = createRecipe('alice')
+
+        const first = assignMeal('alice', WEEK, 'Tuesday', 'Lunch', recipeId)
+        expect(first.success).toBe(true)
+
+        // Re-assigning to the exact same slot should succeed (it skips itself)
+        const second = assignMeal('alice', WEEK, 'Tuesday', 'Lunch', recipeId)
+        expect(second.success).toBe(true)
+    })
+
+    it('rejects an invalid day', () => {
+        const recipeId = createRecipe('alice')
+        const result = assignMeal('alice', WEEK, 'Funday', 'Breakfast', recipeId)
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('Invalid day')
+    })
+
+    it('rejects an invalid meal type', () => {
+        const recipeId = createRecipe('alice')
+        const result = assignMeal('alice', WEEK, 'Monday', 'Brunch', recipeId)
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('Invalid meal type')
+    })
+
+    it('rejects a non-existent recipe', () => {
+        const result = assignMeal('alice', WEEK, 'Monday', 'Breakfast', 99999)
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('Recipe not found')
+    })
+
+    it('rejects a recipe that does not belong to the user or their friends', () => {
+        const recipeId = createRecipe('bob')
+        getFriends.mockReturnValue([])  // alice has no friends
+        const result = assignMeal('alice', WEEK, 'Monday', 'Breakfast', recipeId)
+        expect(result.success).toBe(false)
+        expect(result.message).toContain('own or friends')
+    })
+})
+
+describe('removeMeal', () => {
+    it('removes an assigned meal', () => {
+        const recipeId = createRecipe('alice')
+        assignMeal('alice', WEEK, 'Monday', 'Breakfast', recipeId)
+        const result = removeMeal('alice', WEEK, 'Monday', 'Breakfast')
+        expect(result.success).toBe(true)
+        expect(result.plan.meals['Monday']['Breakfast']).toBeNull()
+    })
+
+    it('allows adding a previously removed recipe back', () => {
+        const recipeId = createRecipe('alice')
+        assignMeal('alice', WEEK, 'Monday', 'Breakfast', recipeId)
+        removeMeal('alice', WEEK, 'Monday', 'Breakfast')
+
+        // Should succeed since the recipe is no longer in any slot
+        const result = assignMeal('alice', WEEK, 'Wednesday', 'Dinner', recipeId)
+        expect(result.success).toBe(true)
+    })
+})
+
+describe('getMealPlan', () => {
+    it('returns an empty plan for a new week', () => {
+        const plan = getMealPlan('alice', WEEK)
+        expect(plan.username).toBe('alice')
+        expect(plan.weekStart).toBe(WEEK)
+        expect(plan.meals['Monday']['Breakfast']).toBeNull()
+    })
+})

--- a/src/components/mealplan/MealPlan.css
+++ b/src/components/mealplan/MealPlan.css
@@ -407,6 +407,47 @@
     font-size: 0.95rem;
 }
 
+/* ---- Duplicate Prevention ---- */
+.picker-error {
+    background: rgba(251, 191, 36, 0.12);
+    border: 1px solid rgba(251, 191, 36, 0.35);
+    color: #fbbf24;
+    padding: 0.6rem 1rem;
+    border-radius: 0.5rem;
+    margin-bottom: 0.75rem;
+    text-align: center;
+    font-size: 0.88rem;
+    font-weight: 500;
+    animation: mpSlideUp 0.25s ease;
+}
+
+.picker-item-disabled {
+    opacity: 0.45;
+    cursor: not-allowed !important;
+    pointer-events: auto;
+}
+
+.picker-item-disabled:hover {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.08);
+    transform: none;
+}
+
+.duplicate-badge {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.15rem 0.55rem;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #fbbf24;
+    background: rgba(251, 191, 36, 0.12);
+    border: 1px solid rgba(251, 191, 36, 0.25);
+    border-radius: 2rem;
+    vertical-align: middle;
+}
+
 .picker-close {
     display: block;
     width: 100%;

--- a/src/components/mealplan/MealPlanPage.jsx
+++ b/src/components/mealplan/MealPlanPage.jsx
@@ -365,7 +365,7 @@ function MealPlanPage() {
                                         <span className="assign-arrow">→</span>
                                     </div>
                                     )
-                                }))
+                                })
                             )}
                         </div>
                         <button className="picker-close" onClick={() => { setPickerSlot(null); setPickerSearch(''); setPickerError('') }}>

--- a/src/components/mealplan/MealPlanPage.jsx
+++ b/src/components/mealplan/MealPlanPage.jsx
@@ -47,6 +47,7 @@ function MealPlanPage() {
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState('')
     const [success, setSuccess] = useState('')
+    const [pickerError, setPickerError] = useState('')   // error shown inside picker modal
 
     // Modal state
     const [pickerSlot, setPickerSlot] = useState(null)   // { day, mealType }
@@ -99,10 +100,39 @@ function MealPlanPage() {
         }
     }, [success])
 
+    useEffect(() => {
+        if (error) {
+            const t = setTimeout(() => setError(''), 5000)
+            return () => clearTimeout(t)
+        }
+    }, [error])
+
     /* ── Actions ────────────────────────────────── */
+
+    /* ── Duplicate detection helper ──────────── */
+    /** Returns a Set of recipeIds already used in the current week's plan. */
+    const usedRecipeIds = (() => {
+        const ids = new Set()
+        if (!plan?.meals) return ids
+        for (const day of DAYS) {
+            for (const mt of MEAL_TYPES) {
+                const slot = plan.meals[day]?.[mt]
+                if (slot?.recipeId != null) ids.add(slot.recipeId)
+            }
+        }
+        return ids
+    })()
 
     const handleAssign = async (recipe) => {
         if (!pickerSlot) return
+
+        // Client-side duplicate guard
+        if (usedRecipeIds.has(recipe.id)) {
+            setPickerError(`"${recipe.title}" is already in your meal plan this week!`)
+            return
+        }
+
+        setPickerError('')
         try {
             const res = await fetch('/meal-plan', {
                 method: 'POST',
@@ -119,12 +149,14 @@ function MealPlanPage() {
                 setPlan(data.plan)
                 setPickerSlot(null)
                 setPickerSearch('')
+                setPickerError('')
                 setSuccess(`Assigned "${recipe.title}" to ${pickerSlot.day} ${pickerSlot.mealType}`)
             } else {
-                setError(data.message || 'Failed to assign meal')
+                // Show duplicate / other error inside the picker so user sees it
+                setPickerError(data.message || 'Failed to assign meal')
             }
         } catch {
-            setError('Could not connect to server')
+            setPickerError('Could not connect to server')
         }
     }
 
@@ -149,6 +181,7 @@ function MealPlanPage() {
     }
 
     const handleCellClick = (day, mealType) => {
+        setPickerError('')
         const meal = plan?.meals?.[day]?.[mealType]
         if (meal) {
             // Look up full recipe data if we have it
@@ -296,6 +329,11 @@ function MealPlanPage() {
                             onChange={e => setPickerSearch(e.target.value)}
                             autoFocus
                         />
+                        {pickerError && (
+                            <div className="picker-error" id="picker-duplicate-error">
+                                ⚠️ {pickerError}
+                            </div>
+                        )}
                         <div className="picker-list">
                             {filteredPickerRecipes.length === 0 ? (
                                 <div className="picker-empty">
@@ -304,10 +342,20 @@ function MealPlanPage() {
                                         : 'No recipes match your search.'}
                                 </div>
                             ) : (
-                                filteredPickerRecipes.map(recipe => (
-                                    <div key={recipe.id} className="picker-item" onClick={() => handleAssign(recipe)}>
+                                filteredPickerRecipes.map(recipe => {
+                                    const isDuplicate = usedRecipeIds.has(recipe.id)
+                                    return (
+                                    <div
+                                        key={recipe.id}
+                                        className={`picker-item ${isDuplicate ? 'picker-item-disabled' : ''}`}
+                                        onClick={() => !isDuplicate && handleAssign(recipe)}
+                                        title={isDuplicate ? 'Already in your plan this week' : ''}
+                                    >
                                         <div className="picker-item-info">
-                                            <div className="picker-item-title">{recipe.title}</div>
+                                            <div className="picker-item-title">
+                                                {recipe.title}
+                                                {isDuplicate && <span className="duplicate-badge">Already Planned</span>}
+                                            </div>
                                             <div className="picker-item-meta">
                                                 {recipe.prepTime ? `⏱ ${recipe.prepTime}m` : ''}
                                                 {recipe.difficulty ? ` · ${recipe.difficulty}` : ''}
@@ -316,10 +364,11 @@ function MealPlanPage() {
                                         </div>
                                         <span className="assign-arrow">→</span>
                                     </div>
-                                ))
+                                    )
+                                }))
                             )}
                         </div>
-                        <button className="picker-close" onClick={() => { setPickerSlot(null); setPickerSearch('') }}>
+                        <button className="picker-close" onClick={() => { setPickerSlot(null); setPickerSearch(''); setPickerError('') }}>
                             Cancel
                         </button>
                     </div>


### PR DESCRIPTION
Story: As a user, I want my weekly meal planner to prevent duplicate meals.

Backend:
- Duplicate check already existed in MealPlanManagement.assignMeal (lines 144-158)
- Prevents writing duplicate recipes to the same week's plan

Frontend (MealPlanPage.jsx):
- Client-side duplicate detection: recipes already in the plan are greyed out with an 'Already Planned' badge in the recipe picker
- Error message displayed inside the picker modal when a duplicate is attempted
- Banners now auto-dismiss after 5 seconds

Tests (MealPlanManagement.test.js — 11 new tests):
- Verifies duplicate rejection across different slots in the same week
- Verifies same recipe allowed in different weeks
- Verifies re-assignment to the same slot (overwrite) still works
- Covers invalid day, invalid meal type, non-existent recipe, and ownership

